### PR TITLE
[AUDIT/FIX] Issue #177 - Staked tokens can be provided as liquidity

### DIFF
--- a/packages/contracts/src/FluidLocker.sol
+++ b/packages/contracts/src/FluidLocker.sol
@@ -425,6 +425,11 @@ contract FluidLocker is Initializable, ReentrancyGuard, IFluidLocker {
         // Pumponomics (market buy SUP with 1% of the provided paired asset)
         _pump(weth, ethAmount * BP_PUMP_RATIO / BP_DENOMINATOR);
 
+        // Ensure that the locker has enough available balance to provide liquidity
+        if (getAvailableBalance() < supAmount) {
+            revert INSUFFICIENT_AVAILABLE_BALANCE();
+        }
+
         // Get the amount of paired asset tokens in the locker
         uint256 ethLPAmount = IERC20(weth).balanceOf(address(this));
 

--- a/packages/contracts/src/interfaces/IFluidLocker.sol
+++ b/packages/contracts/src/interfaces/IFluidLocker.sol
@@ -80,7 +80,7 @@ interface IFluidLocker {
     /// @notice Error thrown when attempting to unstake from locker that does not have staked $FLUID
     error NO_FLUID_TO_UNSTAKE();
 
-    /// @notice Error thrown when attempting to stake from locker that does not have enough available $FLUID
+    /// @notice Error thrown when attempting to stake or to LP from locker that does not have enough available $FLUID
     error INSUFFICIENT_AVAILABLE_BALANCE();
 
     /// @notice Error thrown when attempting to unstake from locker that does not have enough staked $FLUID


### PR DESCRIPTION
[Link to Sherlock Issue](https://audits.sherlock.xyz/contests/968/voting/177)

**_Implementation Details :_**

This PR aims to fix the provide liquidity function that was allowing user to LP with Staked tokens

Now, when providing liquidity, the available balance is checked, ensuring that staked tokens cannot be used to LP.