### PR TITLE
[AUDIT/FIX] Issue #50 - Tax Distribution Pools without units prevents users from unlocking 

### DIFF
--- a/packages/contracts/src/FluidLocker.sol
+++ b/packages/contracts/src/FluidLocker.sol
@@ -330,12 +330,14 @@ contract FluidLocker is Initializable, ReentrancyGuard, IFluidLocker {
 
         // Check if there will be a tax distribution event
         if (unlockPeriod < _MAX_UNLOCK_PERIOD) {
-            // Ensure that the tax distribution pools have at least one unit distributed
-            if (STAKER_DISTRIBUTION_POOL.getTotalUnits() == 0) {
+            (uint256 stakerAllocation, uint256 providerAllocation) = STAKING_REWARD_CONTROLLER.getTaxAllocation();
+
+            // Ensure that the tax distribution pools have at least one unit distributed (if the tax allocation is greater than 0)
+            if (STAKER_DISTRIBUTION_POOL.getTotalUnits() == 0 && stakerAllocation > 0) {
                 revert STAKER_DISTRIBUTION_POOL_HAS_NO_UNITS();
             }
 
-            if (LP_DISTRIBUTION_POOL.getTotalUnits() == 0) {
+            if (LP_DISTRIBUTION_POOL.getTotalUnits() == 0 && providerAllocation > 0) {
                 revert LP_DISTRIBUTION_POOL_HAS_NO_UNITS();
             }
         }


### PR DESCRIPTION
[Link to Sherlock Issue](https://audits.sherlock.xyz/contests/968/voting/50)

Implementation Details :

This PR attempt to prevent users from being blocked in case Tax Distribution Pools units are 0. 

The condition in `FluidLocker::unlock` now also consider the governance parameter `TaxAllocation taxAllocation` to ensure that if one of the allocation is 0, the empty pool units check is not enforced.