### PR TITLE
[LOCKER] Added helper function to disconnect from pools

### DIFF
--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -198,8 +198,6 @@ forge script script/vesting/DeployVesting.s.sol:DeployVestingScript --ffi --rpc-
 ### Step 3 :
 
 - Execute script to create SupVesting contract for each insiders.
-- Note : Currently, the `SupVestingFactory` contract allows prefunding of the `SupVesting` contracts.
-  We must remain consistent and either prefund or not prefund every `SupVesting` contracts.
 
 ### Step 4 :
 

--- a/packages/contracts/script/upgrades/deploy-locker-impl.s.sol
+++ b/packages/contracts/script/upgrades/deploy-locker-impl.s.sol
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import { Script, console2 } from "forge-std/Script.sol";
+
+import { IStakingRewardController } from "src/interfaces/IStakingRewardController.sol";
+import { IEPProgramManager } from "src/interfaces/IEPProgramManager.sol";
+import { ISuperToken } from "@superfluid-finance/ethereum-contracts/contracts/interfaces/superfluid/ISuperToken.sol";
+import { ISuperfluidPool } from
+    "@superfluid-finance/ethereum-contracts/contracts/interfaces/superfluid/ISuperfluidPool.sol";
+import { FluidLocker } from "src/FluidLocker.sol";
+
+/*
+SUP_ADDRESS=0x0000000000000000000000000000000000000000 \
+TAX_DISTRIBUTION_POOL_ADDRESS=0x0000000000000000000000000000000000000000 \
+PROGRAM_MANAGER_ADDRESS=0x0000000000000000000000000000000000000000 \
+STAKING_REWARD_CONTROLLER_ADDRESS=0x0000000000000000000000000000000000000000 \
+FONTAINE_BEACON_ADDRESS=0x0000000000000000000000000000000000000000 \
+forge script script/upgrades/deploy-locker-impl.s.sol:DeployFluidLockerImplementation --ffi --rpc-url $BASE_SEPOLIA_RPC_URL --broadcast --verify -vvv --etherscan-api-key $BASESCAN_API_KEY
+*/
+contract DeployFluidLockerImplementation is Script {
+    function run() public {
+        _showGitRevision();
+
+        // Deployer settings
+        uint256 deployerPrivKey = vm.envOr("PRIVATE_KEY", uint256(0));
+
+        if (deployerPrivKey != 0) {
+            vm.startBroadcast(deployerPrivKey);
+        } else {
+            vm.startBroadcast();
+        }
+
+        ISuperToken sup = ISuperToken(vm.envAddress("SUP_ADDRESS"));
+        ISuperfluidPool taxDistributionPool = ISuperfluidPool(vm.envAddress("TAX_DISTRIBUTION_POOL_ADDRESS"));
+        IEPProgramManager programManager = IEPProgramManager(vm.envAddress("PROGRAM_MANAGER_ADDRESS"));
+        IStakingRewardController stakingRewardController =
+            IStakingRewardController(vm.envAddress("STAKING_REWARD_CONTROLLER_ADDRESS"));
+        address fontaineBeaconAddress = vm.envAddress("FONTAINE_BEACON_ADDRESS");
+        bool isUnlockAvailable = false;
+
+        address lockerLogicAddress = address(
+            new FluidLocker(
+                sup,
+                taxDistributionPool,
+                programManager,
+                stakingRewardController,
+                fontaineBeaconAddress,
+                settings.unlockStatus
+            )
+        );
+
+        console2.log("LOCKER_LOGIC_ADDRESS=%s", lockerLogicAddress);
+    }
+
+    function _showGitRevision() internal {
+        string[] memory inputs = new string[](2);
+        inputs[0] = "../tasks/show-git-rev.sh";
+        inputs[1] = "forge_ffi_mode";
+        try vm.ffi(inputs) returns (bytes memory res) {
+            console2.log("GIT REVISION : %s", string(res));
+        } catch {
+            console2.log("!! _showGitRevision: FFI not enabled");
+        }
+    }
+}

--- a/packages/contracts/script/upgrades/deploy-locker-impl.s.sol
+++ b/packages/contracts/script/upgrades/deploy-locker-impl.s.sol
@@ -6,8 +6,12 @@ import { Script, console2 } from "forge-std/Script.sol";
 import { IStakingRewardController } from "src/interfaces/IStakingRewardController.sol";
 import { IEPProgramManager } from "src/interfaces/IEPProgramManager.sol";
 import { ISuperToken } from "@superfluid-finance/ethereum-contracts/contracts/interfaces/superfluid/ISuperToken.sol";
-import { ISuperfluidPool } from
-    "@superfluid-finance/ethereum-contracts/contracts/interfaces/superfluid/ISuperfluidPool.sol";
+import {
+    ISuperfluid,
+    ISuperfluidPool,
+    ISuperToken
+} from "@superfluid-finance/ethereum-contracts/contracts/interfaces/superfluid/ISuperfluid.sol";
+
 import { FluidLocker } from "src/FluidLocker.sol";
 
 /*
@@ -46,7 +50,7 @@ contract DeployFluidLockerImplementation is Script {
                 programManager,
                 stakingRewardController,
                 fontaineBeaconAddress,
-                settings.unlockStatus
+                isUnlockAvailable
             )
         );
 

--- a/packages/contracts/src/FluidLocker.sol
+++ b/packages/contracts/src/FluidLocker.sol
@@ -435,9 +435,7 @@ contract FluidLocker is Initializable, ReentrancyGuard, IFluidLocker {
         // Get the corresponding program pool
         ISuperfluidPool programPool = EP_PROGRAM_MANAGER.getProgramPool(programId);
 
-        assert(FLUID.isMemberConnected(address(programPool), address(this)));
-
-        // Connect this locker to the Program Pool
+        // Disconnect this locker from the Program Pool
         FLUID.disconnectPool(programPool);
     }
 

--- a/packages/contracts/src/FluidLocker.sol
+++ b/packages/contracts/src/FluidLocker.sol
@@ -294,7 +294,7 @@ contract FluidLocker is Initializable, ReentrancyGuard, IFluidLocker {
     }
 
     /// @inheritdoc IFluidLocker
-    function connectToPool(uint256 programId) external nonReentrant onlyLockerOwner {
+    function connect(uint256 programId) external nonReentrant onlyLockerOwner {
         // Get the corresponding program pool
         ISuperfluidPool programPool = EP_PROGRAM_MANAGER.getProgramPool(programId);
 
@@ -305,12 +305,12 @@ contract FluidLocker is Initializable, ReentrancyGuard, IFluidLocker {
     }
 
     /// @inheritdoc IFluidLocker
-    function disconnectFromPool(uint256 programId) external nonReentrant onlyLockerOwner {
+    function disconnect(uint256 programId) external nonReentrant onlyLockerOwner {
         _disconnectFromPool(programId);
     }
 
     /// @inheritdoc IFluidLocker
-    function disconnectFromPool(uint256[] memory programIds) external nonReentrant onlyLockerOwner {
+    function disconnect(uint256[] memory programIds) external nonReentrant onlyLockerOwner {
         for (uint256 i; i < programIds.length; ++i) {
             _disconnectFromPool(programIds[i]);
         }

--- a/packages/contracts/src/interfaces/IFluidLocker.sol
+++ b/packages/contracts/src/interfaces/IFluidLocker.sol
@@ -162,6 +162,30 @@ interface IFluidLocker {
      */
     function disconnectFromPool(uint256 programId) external;
 
+    /**
+     * @notice Helper function to help the Locker disconnect from multiple program pools
+     * @dev Only this Locker owner can call this function
+     * @param programIds array of program identifiers corresponding to the pools to disconnect from
+     */
+    function disconnectFromPool(uint256[] memory programIds) external;
+
+    /**
+     * @notice Helper function to help the Locker disconnect from multiple program pools and claim units
+     * @dev Only this Locker owner can call this function
+     * @param programIdsToDisconnect array of program identifiers corresponding to the pools to disconnect from
+     * @param programIdsToClaim array of program identifiers corresponding to the pools to claim units from
+     * @param totalProgramUnits array of total program units to claim
+     * @param nonce Single nonce used for all updates in the batch
+     * @param stackSignature Single signature containing necessary info to update all units in the batch
+     */
+    function disconnectAndClaim(
+        uint256[] memory programIdsToDisconnect,
+        uint256[] memory programIdsToClaim,
+        uint256[] memory totalProgramUnits,
+        uint256 nonce,
+        bytes memory stackSignature
+    ) external;
+
     //   _    ___                 ______                 __  _
     //  | |  / (_)__ _      __   / ____/_  ______  _____/ /_(_)___  ____  _____
     //  | | / / / _ \ | /| / /  / /_  / / / / __ \/ ___/ __/ / __ \/ __ \/ ___/

--- a/packages/contracts/src/interfaces/IFluidLocker.sol
+++ b/packages/contracts/src/interfaces/IFluidLocker.sol
@@ -149,28 +149,28 @@ interface IFluidLocker {
     function unstake() external;
 
     /**
-     * @notice Helper function to help the Locker connect to a program pool
+     * @notice Helper function which connects the Locker to a program pool
      * @dev Only this Locker owner can call this function
      * @param programId program identifier corresponding to the pool to connect to
      */
-    function connectToPool(uint256 programId) external;
+    function connect(uint256 programId) external;
 
     /**
-     * @notice Helper function to help the Locker disconnect from a program pool
+     * @notice Helper function which disconnects the Locker from a program pool
      * @dev Only this Locker owner can call this function
      * @param programId program identifier corresponding to the pool to connect to
      */
-    function disconnectFromPool(uint256 programId) external;
+    function disconnect(uint256 programId) external;
 
     /**
-     * @notice Helper function to help the Locker disconnect from multiple program pools
+     * @notice Helper function which disconnects the Locker from multiple program pools
      * @dev Only this Locker owner can call this function
      * @param programIds array of program identifiers corresponding to the pools to disconnect from
      */
-    function disconnectFromPool(uint256[] memory programIds) external;
+    function disconnect(uint256[] memory programIds) external;
 
     /**
-     * @notice Helper function to help the Locker disconnect from multiple program pools and claim units
+     * @notice Helper function which combines batched disconnectFromPool and claim into one call.
      * @dev Only this Locker owner can call this function
      * @param programIdsToDisconnect array of program identifiers corresponding to the pools to disconnect from
      * @param programIdsToClaim array of program identifiers corresponding to the pools to claim units from

--- a/packages/contracts/test/FluidLocker.t.sol
+++ b/packages/contracts/test/FluidLocker.t.sol
@@ -139,10 +139,10 @@ contract FluidLockerTest is SFTest {
 
         vm.prank(BOB);
         vm.expectRevert(IFluidLocker.NOT_LOCKER_OWNER.selector);
-        aliceLocker.connectToPool(PROGRAM_0);
+        aliceLocker.connect(PROGRAM_0);
 
         vm.prank(ALICE);
-        aliceLocker.connectToPool(PROGRAM_0);
+        aliceLocker.connect(PROGRAM_0);
 
         assertEq(
             _fluid.balanceOf(address(aliceLocker)),
@@ -168,10 +168,10 @@ contract FluidLockerTest is SFTest {
 
         vm.prank(BOB);
         vm.expectRevert(IFluidLocker.NOT_LOCKER_OWNER.selector);
-        aliceLocker.disconnectFromPool(PROGRAM_0);
+        aliceLocker.disconnect(PROGRAM_0);
 
         vm.prank(ALICE);
-        aliceLocker.disconnectFromPool(PROGRAM_0);
+        aliceLocker.disconnect(PROGRAM_0);
 
         assertEq(
             _fluid.isMemberConnected(address(programPools[0]), address(aliceLocker)),
@@ -210,10 +210,10 @@ contract FluidLockerTest is SFTest {
 
         vm.prank(BOB);
         vm.expectRevert(IFluidLocker.NOT_LOCKER_OWNER.selector);
-        aliceLocker.disconnectFromPool(programIds);
+        aliceLocker.disconnect(programIds);
 
         vm.prank(ALICE);
-        aliceLocker.disconnectFromPool(programIds);
+        aliceLocker.disconnect(programIds);
 
         assertEq(
             _fluid.isMemberConnected(address(programPools[0]), address(aliceLocker)),

--- a/packages/contracts/test/FluidLocker.t.sol
+++ b/packages/contracts/test/FluidLocker.t.sol
@@ -180,6 +180,122 @@ contract FluidLockerTest is SFTest {
         );
     }
 
+    function testDisconnectFromPools(uint256 units) external virtual {
+        units = bound(units, 1, 1_000_000);
+
+        uint256 nonce0 = _programManager.getNextValidNonce(PROGRAM_0, ALICE);
+        bytes memory signature0 = _helperGenerateSignature(signerPkey, ALICE, units, PROGRAM_0, nonce0);
+        uint256 nonce1 = _programManager.getNextValidNonce(PROGRAM_1, ALICE);
+        bytes memory signature1 = _helperGenerateSignature(signerPkey, ALICE, units, PROGRAM_1, nonce1);
+
+        vm.prank(ALICE);
+        aliceLocker.claim(PROGRAM_0, units, nonce0, signature0);
+        aliceLocker.claim(PROGRAM_1, units, nonce1, signature1);
+
+        assertEq(
+            _fluid.isMemberConnected(address(programPools[0]), address(aliceLocker)),
+            true,
+            "Locker should be connected to pool"
+        );
+
+        assertEq(
+            _fluid.isMemberConnected(address(programPools[1]), address(aliceLocker)),
+            true,
+            "Locker should be connected to pool"
+        );
+
+        uint256[] memory programIds = new uint256[](2);
+        programIds[0] = PROGRAM_0;
+        programIds[1] = PROGRAM_1;
+
+        vm.prank(BOB);
+        vm.expectRevert(IFluidLocker.NOT_LOCKER_OWNER.selector);
+        aliceLocker.disconnectFromPool(programIds);
+
+        vm.prank(ALICE);
+        aliceLocker.disconnectFromPool(programIds);
+
+        assertEq(
+            _fluid.isMemberConnected(address(programPools[0]), address(aliceLocker)),
+            false,
+            "Locker should be disconnected from pool"
+        );
+
+        assertEq(
+            _fluid.isMemberConnected(address(programPools[1]), address(aliceLocker)),
+            false,
+            "Locker should be disconnected from pool"
+        );
+    }
+
+    function testDisconnectAndClaim(uint256 units) external virtual {
+        units = bound(units, 1, 1_000_000);
+
+        uint256 nonce0 = _programManager.getNextValidNonce(PROGRAM_0, ALICE);
+        bytes memory signature0 = _helperGenerateSignature(signerPkey, ALICE, units, PROGRAM_0, nonce0);
+        uint256 nonce1 = _programManager.getNextValidNonce(PROGRAM_1, ALICE);
+        bytes memory signature1 = _helperGenerateSignature(signerPkey, ALICE, units, PROGRAM_1, nonce1);
+        uint256 nonce2 = _programManager.getNextValidNonce(PROGRAM_2, ALICE);
+        bytes memory signature2 = _helperGenerateSignature(signerPkey, ALICE, units, PROGRAM_2, nonce2);
+
+        vm.prank(ALICE);
+        aliceLocker.claim(PROGRAM_0, units, nonce0, signature0);
+        aliceLocker.claim(PROGRAM_1, units, nonce1, signature1);
+
+        assertEq(
+            _fluid.isMemberConnected(address(programPools[0]), address(aliceLocker)),
+            true,
+            "Locker should be connected to pool"
+        );
+
+        assertEq(
+            _fluid.isMemberConnected(address(programPools[1]), address(aliceLocker)),
+            true,
+            "Locker should be connected to pool"
+        );
+
+        assertEq(
+            _fluid.isMemberConnected(address(programPools[2]), address(aliceLocker)),
+            false,
+            "Locker should be not be connected to pool"
+        );
+
+        uint256[] memory programIdsToDisconnect = new uint256[](2);
+        programIdsToDisconnect[0] = PROGRAM_0;
+        programIdsToDisconnect[1] = PROGRAM_1;
+
+        uint256[] memory programIdsToClaim = new uint256[](1);
+        programIdsToClaim[0] = PROGRAM_2;
+
+        uint256[] memory totalProgramUnits = new uint256[](1);
+        totalProgramUnits[0] = units;
+
+        vm.prank(BOB);
+        vm.expectRevert(IFluidLocker.NOT_LOCKER_OWNER.selector);
+        aliceLocker.disconnectAndClaim(programIdsToDisconnect, programIdsToClaim, totalProgramUnits, nonce2, signature2);
+
+        vm.prank(ALICE);
+        aliceLocker.disconnectAndClaim(programIdsToDisconnect, programIdsToClaim, totalProgramUnits, nonce2, signature2);
+
+        assertEq(
+            _fluid.isMemberConnected(address(programPools[0]), address(aliceLocker)),
+            false,
+            "Locker should be disconnected from pool"
+        );
+
+        assertEq(
+            _fluid.isMemberConnected(address(programPools[1]), address(aliceLocker)),
+            false,
+            "Locker should be disconnected from pool"
+        );
+
+        assertEq(
+            _fluid.isMemberConnected(address(programPools[2]), address(aliceLocker)),
+            true,
+            "Locker should be connected to pool"
+        );
+    }
+
     function testLock(uint256 amount) external virtual {
         amount = bound(amount, 1, 1e24);
         assertEq(_fluidSuperToken.balanceOf(address(aliceLocker)), 0, "incorrect balance before operation");


### PR DESCRIPTION
Streamline FluidLocker functions for claiming and disconnecting from pools

- Consolidated claim logic into _claim and _claimBatch internal functions.
- Added disconnectFromPool overload for batch disconnection.
- Introduced disconnectAndClaim function to handle disconnection and claiming in one call.
- Improved code readability and maintainability by reducing redundancy.