### PR TITLE
[VESTING] Handle manual stream close edge case

### DIFF
--- a/packages/contracts/src/vesting/SupVesting.sol
+++ b/packages/contracts/src/vesting/SupVesting.sol
@@ -121,9 +121,12 @@ contract SupVesting is ISupVesting {
         // Close the flow between this contract and the recipient
         SUP.flow(RECIPIENT, 0);
 
-        // Delete the vesting schedule
-        VESTING_SCHEDULER.deleteVestingSchedule(SUP, RECIPIENT, bytes(""));
-
+        IVestingSchedulerV2.VestingSchedule memory vs =
+            VESTING_SCHEDULER.getVestingSchedule(address(SUP), address(this), RECIPIENT);
+        if (vs.endDate != 0) {
+            // Delete the vesting schedule if it is not already deleted
+            VESTING_SCHEDULER.deleteVestingSchedule(SUP, RECIPIENT, bytes(""));
+        }
         // Fetch the remaining balance of the vesting contract
         uint256 remainingBalance = SUP.balanceOf(address(this));
 


### PR DESCRIPTION
This PR intend to solve the case where :
- Schedule recipient manually close their stream flowing from their SUP Vesting contract
- the Schedule end is executed (VestingSchedulerV2::executeEndVesting)

Previously, the call `SupVesting::emergencyWithdraw` would revert (as `VestingSchedulerV2::deleteVestingSchedule` reverts). 

Now, that case is handled, the call can be performed, remaining tokens are transferred to the treasury.