### PR TITLE
[FEAT] Add `FluidLocker::netAssetOf` helper function

### DIFF
--- a/packages/contracts/src/FluidLocker.sol
+++ b/packages/contracts/src/FluidLocker.sol
@@ -54,6 +54,7 @@ import { INonfungiblePositionManager } from "@uniswap/v3-periphery/contracts/int
 import { IV3SwapRouter } from "@uniswap/swap-router-contracts/contracts/interfaces/IV3SwapRouter.sol";
 import { TransferHelper } from "@uniswap/v3-periphery/contracts/libraries/TransferHelper.sol";
 import { TickMath } from "@uniswap/v3-core/contracts/libraries/TickMath.sol";
+import { LiquidityAmounts } from "@uniswap/v3-periphery/contracts/libraries/LiquidityAmounts.sol";
 
 using SuperTokenV1Library for ISuperToken;
 using SafeCast for int256;
@@ -585,6 +586,28 @@ contract FluidLocker is Initializable, ReentrancyGuard, IFluidLocker {
     //  | | / / / _ \ | /| / /  / /_  / / / / __ \/ ___/ __/ / __ \/ __ \/ ___/
     //  | |/ / /  __/ |/ |/ /  / __/ / /_/ / / / / /__/ /_/ / /_/ / / / (__  )
     //  |___/_/\___/|__/|__/  /_/    \__,_/_/ /_/\___/\__/_/\____/_/ /_/____/
+
+    /// @inheritdoc IFluidLocker
+    function netAssetOf() public view returns (uint256 netAsset) {
+        // Get the current price of the SUP/ETHx pool
+        (uint160 sqrtPriceX96,,,,,,) = ETH_SUP_POOL.slot0();
+
+        // Calculate the lower and upper price bounds (positions are full range)
+        int24 tickSpacing = ETH_SUP_POOL.tickSpacing();
+        uint160 sqrtPriceLowerX96 = TickMath.getSqrtRatioAtTick((TickMath.MIN_TICK / tickSpacing) * tickSpacing);
+        uint160 sqrtPriceUpperX96 = TickMath.getSqrtRatioAtTick((TickMath.MAX_TICK / tickSpacing) * tickSpacing);
+
+        // Get the amount of SUP and ETHx in the position
+        (uint256 amount0, uint256 amount1) = LiquidityAmounts.getAmountsForLiquidity(
+            sqrtPriceX96, sqrtPriceLowerX96, sqrtPriceUpperX96, uint128(_liquidityBalance)
+        );
+
+        // Get the amount of SUP in the position
+        uint256 supAmount = ETH_SUP_POOL.token0() == address(FLUID) ? amount0 : amount1;
+
+        // Add the amount of SUP in the position to the balance of FLUID in the locker
+        netAsset = supAmount + FLUID.balanceOf(address(this));
+    }
 
     /// @inheritdoc IFluidLocker
     function getFlowRatePerProgram(uint256 programId) public view returns (int96 flowRate) {

--- a/packages/contracts/src/FluidLocker.sol
+++ b/packages/contracts/src/FluidLocker.sol
@@ -589,6 +589,15 @@ contract FluidLocker is Initializable, ReentrancyGuard, IFluidLocker {
 
     /// @inheritdoc IFluidLocker
     function netAssetOf() public view returns (uint256 netAsset) {
+        // Get the amount of SUP in the liquidity positions
+        (uint256 supAmount,) = getLiquidityPositionsAssets();
+
+        // Add the amount of SUP in the position to the balance of FLUID in the locker
+        netAsset = supAmount + FLUID.balanceOf(address(this));
+    }
+
+    /// @inheritdoc IFluidLocker
+    function getLiquidityPositionsAssets() public view returns (uint256 supAmount, uint256 ethxAmount) {
         // Get the current price of the SUP/ETHx pool
         (uint160 sqrtPriceX96,,,,,,) = ETH_SUP_POOL.slot0();
 
@@ -597,16 +606,15 @@ contract FluidLocker is Initializable, ReentrancyGuard, IFluidLocker {
         uint160 sqrtPriceLowerX96 = TickMath.getSqrtRatioAtTick((TickMath.MIN_TICK / tickSpacing) * tickSpacing);
         uint160 sqrtPriceUpperX96 = TickMath.getSqrtRatioAtTick((TickMath.MAX_TICK / tickSpacing) * tickSpacing);
 
-        // Get the amount of SUP and ETHx in the position
-        (uint256 amount0, uint256 amount1) = LiquidityAmounts.getAmountsForLiquidity(
-            sqrtPriceX96, sqrtPriceLowerX96, sqrtPriceUpperX96, uint128(_liquidityBalance)
-        );
-
-        // Get the amount of SUP in the position
-        uint256 supAmount = ETH_SUP_POOL.token0() == address(FLUID) ? amount0 : amount1;
-
-        // Add the amount of SUP in the position to the balance of FLUID in the locker
-        netAsset = supAmount + FLUID.balanceOf(address(this));
+        if (ETH_SUP_POOL.token0() == address(FLUID)) {
+            (supAmount, ethxAmount) = LiquidityAmounts.getAmountsForLiquidity(
+                sqrtPriceX96, sqrtPriceLowerX96, sqrtPriceUpperX96, uint128(_liquidityBalance)
+            );
+        } else {
+            (ethxAmount, supAmount) = LiquidityAmounts.getAmountsForLiquidity(
+                sqrtPriceX96, sqrtPriceLowerX96, sqrtPriceUpperX96, uint128(_liquidityBalance)
+            );
+        }
     }
 
     /// @inheritdoc IFluidLocker

--- a/packages/contracts/src/FluidLocker.sol
+++ b/packages/contracts/src/FluidLocker.sol
@@ -599,9 +599,11 @@ contract FluidLocker is Initializable, ReentrancyGuard, IFluidLocker {
     /// @inheritdoc IFluidLocker
     function getLiquidityPositionsAssets() public view returns (uint256 supAmount, uint256 ethxAmount) {
         // Get the current price of the SUP/ETHx pool
+        // WARNING : this call is subject to MEV and Uniswap price manipulation attacks
         (uint160 sqrtPriceX96,,,,,,) = ETH_SUP_POOL.slot0();
 
-        // Calculate the lower and upper price bounds (positions are full range)
+        // Calculate the lower and upper price bounds 
+        // It is assumed that the liquidity positions are full range
         int24 tickSpacing = ETH_SUP_POOL.tickSpacing();
         uint160 sqrtPriceLowerX96 = TickMath.getSqrtRatioAtTick((TickMath.MIN_TICK / tickSpacing) * tickSpacing);
         uint160 sqrtPriceUpperX96 = TickMath.getSqrtRatioAtTick((TickMath.MAX_TICK / tickSpacing) * tickSpacing);

--- a/packages/contracts/src/interfaces/IFluidLocker.sol
+++ b/packages/contracts/src/interfaces/IFluidLocker.sol
@@ -312,6 +312,12 @@ interface IFluidLocker {
     //  |___/_/\___/|__/|__/  /_/    \__,_/_/ /_/\___/\__/_/\____/_/ /_/____/
 
     /**
+     * @notice Returns the net asset value of the locker
+     * @return netAsset the net asset value of the locker
+     */
+    function netAssetOf() external view returns (uint256 netAsset);
+
+    /**
      * @notice Returns the flowrate received by this Locker for the given program identifier
      * @param programId program identifier to query
      * @return flowRate the flowrate received by this Locker for the given program identifier

--- a/packages/contracts/src/interfaces/IFluidLocker.sol
+++ b/packages/contracts/src/interfaces/IFluidLocker.sol
@@ -318,6 +318,13 @@ interface IFluidLocker {
     function netAssetOf() external view returns (uint256 netAsset);
 
     /**
+     * @notice Returns the amount of SUP and ETHx in the liquidity positions held by this Locker
+     * @return supAmount the amount of SUP in the liquidity positions
+     * @return ethxAmount the amount of ETHx in the liquidity positions
+     */
+    function getLiquidityPositionsAssets() external view returns (uint256 supAmount, uint256 ethxAmount);
+
+    /**
      * @notice Returns the flowrate received by this Locker for the given program identifier
      * @param programId program identifier to query
      * @return flowRate the flowrate received by this Locker for the given program identifier

--- a/packages/contracts/src/interfaces/IFluidLocker.sol
+++ b/packages/contracts/src/interfaces/IFluidLocker.sol
@@ -313,12 +313,14 @@ interface IFluidLocker {
 
     /**
      * @notice Returns the net asset value of the locker
+     * @dev WARNING: This function is not MEV resistant and prone to Uniswap price manipulation attacks.
      * @return netAsset the net asset value of the locker
      */
     function netAssetOf() external view returns (uint256 netAsset);
 
     /**
      * @notice Returns the amount of SUP and ETHx in the liquidity positions held by this Locker
+     * @dev WARNING: This function is not MEV resistant and prone to Uniswap price manipulation attacks.
      * @return supAmount the amount of SUP in the liquidity positions
      * @return ethxAmount the amount of ETHx in the liquidity positions
      */

--- a/packages/contracts/test/FluidLocker.t.sol
+++ b/packages/contracts/test/FluidLocker.t.sol
@@ -1888,6 +1888,66 @@ contract FluidLockerTTETest is FluidLockerBaseTest {
         vm.prank(ADMIN);
         beacon.upgradeTo(_unlockableLockerLogic);
     }
+
+    function test_netAssetOf(uint256 ethAmount, uint256 stakedSupAmount) external {
+        ethAmount = bound(ethAmount, 0.001 ether, 1000 ether);
+        stakedSupAmount = bound(stakedSupAmount, 1 ether, 1_000_000 ether);
+
+        _helperUpgradeLocker();
+
+        uint256 supAmountToLP = ethAmount * 20_000 * 9900 / 10_000;
+
+        _helperFundLocker(address(aliceLocker), supAmountToLP + stakedSupAmount);
+
+        vm.startPrank(ALICE);
+        aliceLocker.stake(stakedSupAmount);
+        aliceLocker.provideLiquidity{ value: ethAmount }(supAmountToLP);
+        vm.stopPrank();
+
+        uint256 expectedSupPumpAmount = ethAmount * 20_000 * 100 / 10_000;
+
+        uint256 netAsset = aliceLocker.netAssetOf();
+
+        assertApproxEqAbs(
+            netAsset,
+            supAmountToLP + expectedSupPumpAmount + stakedSupAmount,
+            netAsset * 10 / 10_000, // 0.1% tolerance
+            "net asset should be approximately equal to the SUP amount in the liquidity positions + the expected SUP pump amount"
+        );
+    }
+
+    function test_getLiquidityPositionsAssets(uint256 ethAmount) external {
+        ethAmount = bound(ethAmount, 0.001 ether, 1000 ether);
+
+        _helperUpgradeLocker();
+
+        uint256 supAmountToLP = ethAmount * 20_000 * 9900 / 10_000;
+
+        _helperFundLocker(address(aliceLocker), supAmountToLP);
+
+        vm.startPrank(ALICE);
+        aliceLocker.provideLiquidity{ value: ethAmount }(supAmountToLP);
+        vm.stopPrank();
+
+        uint256 expectedEthxDumpAmount = ethAmount * 100 / 10_000;
+        uint256 expectedSupPumpAmount = ethAmount * 20_000 * 100 / 10_000;
+
+        (uint256 supAmountInLp, uint256 ethxAmountInLp) = aliceLocker.getLiquidityPositionsAssets();
+
+        assertApproxEqAbs(
+            supAmountInLp,
+            supAmountToLP + expectedSupPumpAmount - _fluidSuperToken.balanceOf(address(aliceLocker)),
+            supAmountInLp * 10 / 10_000, // 0.1% tolerance
+            "sup amount in liquidity positions should be approximately equal to the SUP amount in the liquidity positions + the expected SUP pump amount"
+        );
+
+        assertApproxEqAbs(
+            ethxAmountInLp,
+            ethAmount - expectedEthxDumpAmount,
+            ethxAmountInLp * 10 / 10_000, // 0.1% tolerance
+            "ethx amount in liquidity positions should be approximately equal to the ETH amount in the liquidity positions"
+        );
+    }
 }
 
 contract FluidLockerLayoutTest is FluidLocker {


### PR DESCRIPTION
This PR intend to : 

- add helper view function `FluidLocker::netAssetOf` and `FluidLocker::getLiquidityPositionsAssets` 

these function now offer deterministic ways to query the amount of SUP and ETHx contained by the Reserve liquidity positions. 